### PR TITLE
Added Show API to Keystone

### DIFF
--- a/src/emuvim/api/heat/heat_parser.py
+++ b/src/emuvim/api/heat/heat_parser.py
@@ -113,8 +113,9 @@ class HeatParser:
             return
 
         if 'OS::Nova::Server' in resource['type']:
-            compute_name = str(dc_label) + "_" + str(stack.stack_name) + '_' + str(resource['properties']['name'])
-            shortened_name = self.shorten_server_name(compute_name, stack)
+            compute_name = str(dc_label) + '_' + str(stack.stack_name) + '_' + str(resource['properties']['name'])
+            shortened_name = str(dc_label) + '_' + str(stack.stack_name) + '_' +\
+                             self.shorten_server_name(str(resource['properties']['name']), stack)
             stack.server_names[shortened_name] = compute_name
             flavor = resource['properties']['flavor']
             nw_list = resource['properties']['networks']
@@ -185,14 +186,13 @@ class HeatParser:
                 print('Could not create Router: ' + e.message)
             return
 
-    # TODO find a better way to shorten the name (e.g. dc_stacknr_shortName)
     def shorten_server_name(self, server_name, stack):
         shortened_name = server_name.split(':',1)[0]
         shortened_name = shortened_name.replace("-", "_")
-        shortened_name = shortened_name[0:24]
+        shortened_name = shortened_name[0:12]
         iterator = 0
         while shortened_name in stack.server_names:
-            shortened_name = shortened_name[0:24] + str(iterator)
+            shortened_name = shortened_name[0:12] + str(iterator)
             iterator += 1
         return shortened_name
 

--- a/src/emuvim/api/heat/openstack_dummies/keystone_dummy_api.py
+++ b/src/emuvim/api/heat/openstack_dummies/keystone_dummy_api.py
@@ -24,6 +24,7 @@ class KeystoneDummyApi(BaseOpenstackDummy):
         ip = in_ip
         port = in_port
         self.api.add_resource(KeystoneListVersions, "/")
+        self.api.add_resource(KeystoneShowAPIv2, "/v2.0")
         self.api.add_resource(KeystoneGetToken, "/v2.0/tokens")
 
     def _start_flask(self):
@@ -61,6 +62,51 @@ class KeystoneListVersions(Resource):
                 "updated": "2014-04-17T00:00:00Z"
             }]
         resp['versions']['values'] = version
+
+        return Response(json.dumps(resp), status=200, mimetype='application/json')
+
+
+class KeystoneShowAPIv2(Resource):
+    global ip, port
+
+    def get(self):
+        logging.debug("API CALL: Show API v2.0 details")
+
+        neutrnonPort = port + 4696
+
+        resp = dict()
+        resp['resources'] = [{
+                "links": [
+                    {
+                        "href": "http://%s:%d/v2.0/subnets" % (ip, neutrnonPort),
+                        "rel": "self"
+                    }
+                ],
+                "name": "subnet",
+                "collection": "subnets"
+            },
+            {
+                "links": [
+                    {
+                        "href": "http://%s:%d/v2.0/networks" % (ip, neutrnonPort),
+                        "rel": "self"
+                    }
+                ],
+                "name": "network",
+                "collection": "networks"
+            },
+            {
+                "links": [
+                    {
+                        "href": "http://%s:%d/v2.0/ports" % (ip, neutrnonPort),
+                        "rel": "self"
+                    }
+                ],
+                "name": "ports",
+                "collection": "ports"
+            }
+        ]
+        # TODO add all API calls
 
         return Response(json.dumps(resp), status=200, mimetype='application/json')
 

--- a/src/emuvim/api/heat/openstack_dummies/neutron_dummy_api.py
+++ b/src/emuvim/api/heat/openstack_dummies/neutron_dummy_api.py
@@ -41,8 +41,6 @@ class NeutronDummyApi(BaseOpenstackDummy):
             self.app.run(self.ip, self.port, debug=True, use_reloader=False)
 
 class NeutronListAPIVersions(Resource):
-    global ip, port
-
     def get(self):
         logging.debug("API CALL: Neutron - List API Versions")
         resp = dict()
@@ -53,7 +51,7 @@ class NeutronListAPIVersions(Resource):
                 "id": "v2.0",
                 "links": [
                     {
-                        "href": "http://%s:%d/v2.0" % (ip, port),
+                        "href": request.url_root + '/v2.0',
                         "rel": "self"
                     }
                 ]
@@ -65,8 +63,6 @@ class NeutronListAPIVersions(Resource):
 
 
 class NeutronShowAPIv2Details(Resource):
-    global ip, port
-
     def get(self):
         logging.debug("API CALL: Neutron - Show API v2 details")
         resp = dict()
@@ -75,7 +71,7 @@ class NeutronShowAPIv2Details(Resource):
         resp['resources'] = [{
                 "links": [
                     {
-                        "href": "http://%s:%d/v2.0/subnets" % (ip, port),
+                        "href": request.url_root + 'v2.0/subnets',
                         "rel": "self"
                     }
                 ],
@@ -85,7 +81,7 @@ class NeutronShowAPIv2Details(Resource):
             {
                 "links": [
                     {
-                        "href": "http://%s:%d/v2.0/networks" % (ip, port),
+                        "href": request.url_root + 'v2.0/networks',
                         "rel": "self"
                     }
                 ],
@@ -95,7 +91,7 @@ class NeutronShowAPIv2Details(Resource):
             {
                 "links": [
                     {
-                        "href": "http://%s:%d/v2.0/ports" % (ip, port),
+                        "href": request.url_root + 'v2.0/ports',
                         "rel": "self"
                     }
                 ],
@@ -115,6 +111,11 @@ class NeutronListNetworks(Resource):
 
         logging.debug("API CALL: Neutron - List networks")
         try:
+
+            if request.args.get('name'):
+                show_network = NeutronShowNetwork()
+                return show_network.get(request.args.get('name'))
+
             network_list = list()
             network_dict = dict()
 
@@ -126,7 +127,6 @@ class NeutronListNetworks(Resource):
             network_dict["networks"] = network_list
 
             return Response(json.dumps(network_dict), status=200, mimetype='application/json')
-
 
         except Exception as ex:
             logging.exception("Neutron: List networks exception.")
@@ -212,6 +212,10 @@ class NeutronListSubnets(Resource):
 
         logging.debug("API CALL: Neutron - List subnets")
         try:
+            if request.args.get('name'):
+                show_subnet = NeutronShowSubnet()
+                return show_subnet.get(request.args.get('name'))
+
             subnet_list = list()
             subnet_dict = dict()
 
@@ -309,6 +313,10 @@ class NeutronListPorts(Resource):
 
         logging.debug("API CALL: Neutron - List ports")
         try:
+            if request.args.get('name'):
+                show_port = NeutronShowPort()
+                return show_port.get(request.args.get('name'))
+
             port_list = list()
             port_dict = dict()
 
@@ -333,7 +341,6 @@ class NeutronShowPort(Resource):
 
         logging.debug("API CALL: Neutron - Show port")
         try:
-
             for stack in compute.stacks.values():
                 for port in stack.ports.values():
                     if port.id == port_id:
@@ -405,7 +412,7 @@ class NeutronUpdatePort(Resource):
 def create_network_dict(network):
     network_dict = dict()
     network_dict["status"] = "ACTIVE"  # TODO do we support inactive networks?
-    network_dict["subnets"] = []  # TODO can we add subnets?
+    network_dict["subnets"] = network.subnet_id  # TODO can we add subnets?
     network_dict["name"] = network.name
     network_dict["admin_state_up"] = True  # TODO is it always true?
     network_dict["tenant_id"] = "c1210485b2424d48804aad5d39c61b8f"  # TODO what should go in here
@@ -419,7 +426,7 @@ def create_subnet_dict(network):
     subnet_dict["name"] = network.subnet_name
     subnet_dict["network_id"] = network.id
     subnet_dict["tenant_id"] = "c1210485b2424d48804aad5d39c61b8f"  # TODO what should go in here?
-    subnet_dict["allocation_pools"] = [{"start": "10.10.0.2", "end": "10.10.0.254"}]  # TODO where do we get the real pools?
+    subnet_dict["allocation_pools"] = [calculate_start_and_end_dict(network.cidr)]
     subnet_dict["gateway_ip"] = network.gateway_ip
     subnet_dict["ip_version"] = "4"  # TODO which versions do we support?
     subnet_dict["cidr"] = network.cidr
@@ -442,3 +449,32 @@ def create_port_dict(port):
     port_dict["status"] = "ACTIVE"  # TODO do we support inactive port?
     port_dict["tenant_id"] = "cf1a5775e766426cb1968766d0191908"  # TODO find real tenant_id
     return port_dict
+
+
+def calculate_start_and_end_dict(cidr):
+    address, suffix = cidr.rsplit('/', 1)
+    int_suffix = int(suffix)
+    int_address = ip_2_int(address)
+    address_space = 2**32 - 1
+
+    for x in range(0, 31-int_suffix):
+        address_space = ~(~address_space | (1 << x))
+
+    start = int_address & address_space
+    end = start + (2**(32-int_suffix) - 1)
+
+    return {'start': int_2_ip(start), 'end': int_2_ip(end)}
+
+
+def ip_2_int(ip):
+    o = map(int, ip.split('.'))
+    res = (16777216 * o[0]) + (65536 * o[1]) + (256 * o[2]) + o[3]
+    return res
+
+
+def int_2_ip(int_ip):
+    o1 = int(int_ip / 16777216) % 256
+    o2 = int(int_ip / 65536) % 256
+    o3 = int(int_ip / 256) % 256
+    o4 = int(int_ip) % 256
+    return '%(o1)s.%(o2)s.%(o3)s.%(o4)s' % locals()


### PR DESCRIPTION
Most commands start with a GET /v2.0 request on port 5001. Thus i added it to avoid 404 errors.
neutron *-show commands don't add a <network_id> to the request but rather add '?fields=...' with the name or id of a Network, Subnet or Port. At the moment check the requests for such parameters and call the function if necessary.
neutron subnet-list will now display the subnets with the correct allocation_pools.