### PR TITLE
Finally the neutron client can create, delete and show - networks etc.

### DIFF
--- a/src/emuvim/api/heat/heat_parser.py
+++ b/src/emuvim/api/heat/heat_parser.py
@@ -96,7 +96,7 @@ class HeatParser:
             return
 
         if 'OS::Neutron::Port' in resource['type']:
-            network = resource['properties']['network']['get_resource']
+            network_name = resource['properties']['network']['get_resource']
             name = resource['properties']['name']
             try:
                 if name not in stack.ports:
@@ -104,7 +104,7 @@ class HeatParser:
                     stack.ports[name].id = str(len(stack.ports)-1)
 
                 for tmp_net in stack.nets.values():
-                    if tmp_net.name == network:
+                    if tmp_net.name == network_name:
                         stack.ports[name].net = tmp_net
                         return
             except Exception as e:
@@ -187,13 +187,17 @@ class HeatParser:
             return
 
     def shorten_server_name(self, server_name, stack):
-        shortened_name = server_name.split(':',1)[0]
-        shortened_name = shortened_name.replace("-", "_")
-        shortened_name = shortened_name[0:12]
+        server_name = self.shorten_name(server_name, 12)
         iterator = 0
-        while shortened_name in stack.server_names:
-            shortened_name = shortened_name[0:12] + str(iterator)
+        while server_name in stack.server_names:
+            server_name = server_name[0:12] + str(iterator)
             iterator += 1
+        return server_name
+
+    def shorten_name(self, name, max_size):
+        shortened_name = name.split(':', 1)[0]
+        shortened_name = shortened_name.replace("-", "_")
+        shortened_name = shortened_name[0:max_size]
         return shortened_name
 
 if __name__ == '__main__':

--- a/src/emuvim/api/heat/openstack_dummies/keystone_dummy_api.py
+++ b/src/emuvim/api/heat/openstack_dummies/keystone_dummy_api.py
@@ -72,40 +72,46 @@ class KeystoneShowAPIv2(Resource):
     def get(self):
         logging.debug("API CALL: Show API v2.0 details")
 
-        neutrnonPort = port + 4696
+        neutrnon_port = port + 4696
+        heat_port = port + 3004
 
         resp = dict()
-        resp['resources'] = [{
-                "links": [
+        resp['version'] = {
+                "status": "stable",
+                "media-types": [
                     {
-                        "href": "http://%s:%d/v2.0/subnets" % (ip, neutrnonPort),
-                        "rel": "self"
+                        "base": "application/json",
+                        "type": "application/vnd.openstack.identity-v2.0+json"
                     }
                 ],
-                "name": "subnet",
-                "collection": "subnets"
-            },
-            {
+                "id": "v2.0",
                 "links": [
                     {
-                        "href": "http://%s:%d/v2.0/networks" % (ip, neutrnonPort),
+                        "href": "http://%s:%d/v2.0" % (ip, port),
                         "rel": "self"
-                    }
-                ],
-                "name": "network",
-                "collection": "networks"
-            },
-            {
-                "links": [
+                    },
                     {
-                        "href": "http://%s:%d/v2.0/ports" % (ip, neutrnonPort),
+                        "href": "http://%s:%d/v2.0/tokens" % (ip, port),
+                        "rel": "self"
+                    },
+                    {
+                        "href": "http://%s:%d/v2.0/networks" % (ip, neutrnon_port),
+                        "rel": "self"
+                    },
+                    {
+                        "href": "http://%s:%d/v2.0/subnets" % (ip, neutrnon_port),
+                        "rel": "self"
+                    },
+                    {
+                        "href": "http://%s:%d/v2.0/ports" % (ip, neutrnon_port),
+                        "rel": "self"
+                    },
+                    {
+                        "href": "http://%s:%d/v1/<tenant_id>/stacks" % (ip, heat_port),
                         "rel": "self"
                     }
-                ],
-                "name": "ports",
-                "collection": "ports"
+                ]
             }
-        ]
         # TODO add all API calls
 
         return Response(json.dumps(resp), status=200, mimetype='application/json')


### PR DESCRIPTION
The answer of the keystone_api will now contain the version (v2.0).
Entry points for the neutron client where wrong - now they should work.
Individual net, subnet and port classes can be requested with the neutron client.
The Delete functions should work now and the delete function for ports was added.
A link will still NOT be created when the net, subnet and port are created - we have to figure out which server should be used and how we specify the two connection points of this link!