### PR TITLE
Ports will now get individual ip-addresses

### DIFF
--- a/src/emuvim/api/heat/heat_parser.py
+++ b/src/emuvim/api/heat/heat_parser.py
@@ -1,6 +1,7 @@
 from __future__ import print_function  # TODO remove when print is no longer needed for debugging
 import yaml
 import sys
+import uuid
 from resources import *
 
 
@@ -70,7 +71,7 @@ class HeatParser:
                 name = resource['properties']['name']
                 if name not in stack.nets:
                     stack.nets[name] = Net(name)
-                    stack.nets[name].id = str(len(stack.nets)-1)
+                    stack.nets[name].id = str(uuid.uuid4())[:15]  # str(len(stack.nets)-1)
 
             except Exception as e:
                 print('Could not create Net: ' + e.message)
@@ -81,14 +82,13 @@ class HeatParser:
                 net_name = resource['properties']['network']['get_resource']
                 if net_name not in stack.nets:
                     stack.nets[net_name] = Net(net_name)
-                    stack.nets[net_name].id = str(len(stack.nets)-1)
+                    stack.nets[net_name].id = str(uuid.uuid4())[:15]  # str(len(stack.nets)-1)
 
-                tmp_net = stack.nets[net_name]
-                tmp_net.subnet_name = resource['properties']['name']
+                stack.nets[net_name].subnet_name = resource['properties']['name']
                 if 'gateway_ip' in resource['properties']:
-                    tmp_net.gateway_ip = resource['properties']['gateway_ip']
-                tmp_net.subnet_id = tmp_net.id  # TODO could there be a different number of subnets than nets?
-                tmp_net.cidr = resource['properties']['cidr']
+                    stack.nets[net_name].gateway_ip = resource['properties']['gateway_ip']
+                stack.nets[net_name].subnet_id = stack.nets[net_name].id  # TODO could there be a different number of subnets than nets?
+                stack.nets[net_name].set_cidr(resource['properties']['cidr'])
             except Exception as e:
                 print('Could not create Subnet: ' + e.message)
             return
@@ -98,11 +98,13 @@ class HeatParser:
                 name = resource['properties']['name']
                 if name not in stack.ports:
                     stack.ports[name] = Port(name)
-                    stack.ports[name].id = str(len(stack.ports)-1)
+                    stack.ports[name].id = str(uuid.uuid4())[:15]  # str(len(stack.ports)-1)
 
                 for tmp_net in stack.nets.values():
-                    if tmp_net.name == resource['properties']['network']['get_resource']:
-                        stack.ports[name].net = tmp_net
+                    if tmp_net.name == resource['properties']['network']['get_resource'] and \
+                       tmp_net.subnet_id is not None:
+                        stack.ports[name].net_id = tmp_net.id
+                        stack.ports[name].ip_address = tmp_net.get_new_ip_address(name)
                         return
             except Exception as e:
                 print('Could not create Port: ' + e.message)
@@ -118,18 +120,17 @@ class HeatParser:
                 if shortened_name not in stack.servers:
                     stack.servers[shortened_name] = Server(shortened_name)
 
-                tmp_server = stack.servers[shortened_name]
-                tmp_server.full_name = compute_name
-                tmp_server.command = '/bin/bash'
-                tmp_server.image = resource['properties']['image']
-                tmp_server.flavor = resource['properties']['flavor']
+                stack.servers[shortened_name].full_name = compute_name
+                stack.servers[shortened_name].command = '/bin/bash'
+                stack.servers[shortened_name].image = resource['properties']['image']
+                stack.servers[shortened_name].flavor = resource['properties']['flavor']
                 for port in nw_list:
                     port_name = port['port']['get_resource']
                     if port_name not in stack.ports:
                         stack.ports[port_name] = Port(port_name)
-                        stack.ports[port_name].id = str(len(stack.ports)-1)
+                        stack.ports[port_name].id = str(uuid.uuid4())[:15]  # str(len(stack.ports)-1)
 
-                    tmp_server.ports.append(stack.ports[port_name])
+                    stack.servers[shortened_name].ports.append(port_name)
             except Exception as e:
                 print('Could not create Server: ' + e.message)
             return
@@ -147,10 +148,9 @@ class HeatParser:
                 if router_name not in stack.routers:
                     stack.routers[router_name] = Router(router_name)
 
-                tmp_router = stack.routers[router_name]
                 for tmp_net in stack.nets.values():
                     if tmp_net.subnet_name == subnet_name:
-                        tmp_router.add_subnet(tmp_net)
+                        stack.routers[router_name].add_subnet(tmp_net)
                         return
             except Exception as e:
                 print('Could not create RouterInterface: ' + e.__repr__())
@@ -163,10 +163,9 @@ class HeatParser:
                 floating_network_id = resource['properties']['floating_network_id']
                 if port_id not in stack.ports:
                     stack.ports[port_id] = Port(port_id)
-                    stack.ports[port_id].id = str(len(stack.ports)-1)
+                    stack.ports[port_id].id = str(uuid.uuid4())[:15]  # str(len(stack.ports)-1)
 
-                tmp_port = stack.ports[port_id]
-                tmp_port.floating_ip = floating_network_id
+                stack.ports[port_id].floating_ip = floating_network_id
             except Exception as e:
                 print('Could not create FloatingIP: ' + e.message)
             return
@@ -196,6 +195,7 @@ class HeatParser:
         shortened_name = shortened_name.replace("-", "_")
         shortened_name = shortened_name[0:max_size]
         return shortened_name
+
 
 if __name__ == '__main__':
     inputFile = open('yamlTest2', 'r')

--- a/src/emuvim/api/heat/openstack_dummies/heat_dummy_api.py
+++ b/src/emuvim/api/heat/openstack_dummies/heat_dummy_api.py
@@ -17,7 +17,7 @@ class HeatDummyApi(BaseOpenstackDummy):
     global compute, ip, port
 
     def __init__(self, in_ip, in_port):
-        global compute
+        global compute, ip, port
 
         super(HeatDummyApi, self).__init__(in_ip, in_port)
         self.compute = None

--- a/src/emuvim/api/heat/openstack_dummies/neutron_dummy_api.py
+++ b/src/emuvim/api/heat/openstack_dummies/neutron_dummy_api.py
@@ -199,6 +199,7 @@ class NeutronCreateNetwork(Resource):
 
                 return Response(json.dumps(tmp_dict), status=201, mimetype='application/json')
 
+            return 'No Stack found to create the Network.', 404
         except Exception as ex:
             logging.exception("Neutron: Create network excepiton.")
             return ex.message, 500
@@ -245,7 +246,7 @@ class NeutronUpdateNetwork(Resource):
 
 class NeutronDeleteNetwork(Resource):
 
-    def delete(self, network_id):  # TODO delete reference port.net too
+    def delete(self, network_id):
         global compute
 
         logging.debug("API CALL: Neutron - Delete network")
@@ -344,10 +345,7 @@ class NeutronCreateSubnet(Resource):
                             return 'Only one subnet per network is supported', 409
 
                         if "cidr" in subnet_dict["subnet"]:
-                            r = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{2}')
-                            if r.match(subnet_dict["subnet"]["cidr"]):
-                                net.cidr = subnet_dict["subnet"]["cidr"]
-                            else:
+                            if not net.set_cidr(subnet_dict["subnet"]["cidr"]):
                                 return 'Wrong CIDR format.', 400
                         else:
                             return 'No CIDR found.', 400
@@ -367,11 +365,6 @@ class NeutronCreateSubnet(Resource):
                             net.subnet_id = str(uuid.uuid4())
                         if "enable_dhcp" in subnet_dict["subnet"]:
                             pass
-
-                        for server in stack.servers.values():
-                            for port in server.ports:
-                                if port.net.id == net_id:
-                                    create_link(net.id)
 
                         tmp_subnet_dict = create_subnet_dict(net)
                         tmp_dict = dict()
@@ -410,7 +403,7 @@ class NeutronUpdateSubnet(Resource):
                         if "ip_version" in subnet_dict["subnet"]:
                             pass
                         if "cidr" in subnet_dict["subnet"]:
-                            net.cidr = subnet_dict["subnet"]["cidr"]
+                            net.set_cidr(subnet_dict["subnet"]["cidr"])
                         if "id" in subnet_dict["subnet"]:
                             net.subnet_id = subnet_dict["subnet"]["id"]
                         if "enable_dhcp" in subnet_dict["subnet"]:
@@ -436,22 +429,21 @@ class NeutronDeleteSubnet(Resource):
             for stack in compute.stacks.values():
                 for net in stack.nets.values():
                     if net.subnet_id == subnet_id:
-                        tmp_server = None
                         for server in stack.servers.values():
-                            for port in server.ports:
-                                if port.net.subnet_id == subnet_id:
-                                    tmp_server = server
-                        if tmp_server is not None:
-                            compute.dc.net.removeLink(
-                                link=None,
-                                node1=compute.dc.containers[tmp_server.name],
-                                node2=compute.dc.switch)
-                        else:
-                            return 'Could not delete link.', 404
+                            for port_name in server.ports:
+                                port = stack[port_name]
+                                if port.net_id == net.id:
+                                    port.ip_address = None
+                                    compute.dc.net.removeLink(
+                                        link=None,
+                                        node1=compute.dc.containers[server.name],
+                                        node2=compute.dc.switch)
 
                         net.subnet_id = None
                         net.subnet_name = None
-                        net.cidr = None
+                        net.set_cidr(None)
+                        net.start_end_dict = None
+                        net.reset_issued_ip_addresses()
 
                         return 'Subnet ' + str(subnet_id) + ' deleted.', 204
 
@@ -534,14 +526,15 @@ class NeutronCreatePort(Resource):
             for stack in compute.stacks.values():
                 for net in stack.nets.values():
                     if net.id == net_id:
+                        port = None
                         if name not in stack.ports:
-                            stack.ports[name] = Port(name)
+                            port = Port(name)
+                            stack.ports[name] = port
                         else:
                             return 'Port name already exists.', 400
 
-                        stack.ports[name].net = net
-                        if net.cidr is not None:  # If cidr exists the subnet was created and we can create the link
-                            create_link(net.id)
+                        port.net_id = net.id
+                        port.ip_address = net.get_new_ip_address(name)
 
                         if "admin_state_up" in port_dict["port"]:
                             pass
@@ -602,6 +595,9 @@ class NeutronUpdatePort(Resource):
                         if "name" in port_dict["port"] and port_dict["port"]["name"] != port.name:
                             old_name = port.name
                             port.name = port_dict["port"]["name"]
+                            for net in stack.nets.values():
+                                if port.net_id == net.id and port.ip_address is not None:
+                                    net.update_port_name_for_ip_address(port.ip_address, port.name)
                             stack.ports[port.name] = stack.ports[old_name]
                             del stack.ports[old_name]
                         if "network_id" in port_dict["port"]:
@@ -634,9 +630,11 @@ class NeutronDeletePort(Resource):
                     if port.id == port_id:
                         port_name = port.name
 
+                        for net in stack.nets.values():
+                            if port.net_id == net.id and port.ip_address is not None:
+                                net.withdraw_ip_address(port.ip_address)
                         for server in stack.servers.values():
-                            if port in server.ports:
-                                del server.ports[server.ports.index(port)]
+                            server.ports.remove(port_name)
                         del stack.ports[port_name]
 
                         return 'Port ' + port_id + ' deleted.', 204
@@ -667,11 +665,11 @@ def create_subnet_dict(network):
     subnet_dict["tenant_id"] = "c1210485b2424d48804aad5d39c61b8f"  # TODO what should go in here?
     subnet_dict["created_at"] = "2016-09-02T17:20:00"
     subnet_dict["dns_nameservers"] = []
-    subnet_dict["allocation_pools"] = [calculate_start_and_end_dict(network.cidr)]
+    subnet_dict["allocation_pools"] = [network.start_end_dict]
     subnet_dict["host_routers"] = []
     subnet_dict["gateway_ip"] = network.gateway_ip
     subnet_dict["ip_version"] = "4"  # TODO which versions do we support?
-    subnet_dict["cidr"] = network.cidr
+    subnet_dict["cidr"] = network._cidr
     subnet_dict["updated_at"] = "2016-09-02T17:20:00"
     subnet_dict["id"] = network.subnet_id  # TODO it is currently the gateway_ip. Where do we get the real id?
     subnet_dict["enable_dhcp"] = False  # TODO do we support DHCP?
@@ -683,65 +681,39 @@ def create_port_dict(port):
     port_dict["admin_state_up"] = True  # TODO is it always true?
     port_dict["device_id"] = "257614cc-e178-4c92-9c61-3b28d40eca44"  # TODO find real values
     port_dict["device_owner"] = ""  # TODO do we have such things?
-    fixed_ips_list = list()  # TODO add something (floating ip? or some ip that is within the network?)
-    port_dict["fixed_ips"] = fixed_ips_list
+    tmp_subnet_id = None
+    for stack in compute.stacks.values():
+        for net in stack.nets.values():
+            if net.id == port.net_id:
+                tmp_subnet_id = net.subnet_id
+                break
+    tmp_ip_address = None
+    if port.ip_address is not None:
+        tmp_ip_address = port.ip_address.rsplit('/', 1)[0]
+    port_dict["fixed_ips"] = [
+                                  {
+                                      "ip_address": tmp_ip_address,
+                                      "subnet_id": tmp_subnet_id
+                                  }
+                             ]
     port_dict["id"] = port.id
     port_dict["mac_address"] = port.mac_address
     port_dict["name"] = port.name
-    if port.net is not None:
-        port_dict["network_id"] = port.net.id
-    else:
-        port_dict["network_id"] = None
+    port_dict["network_id"] = port.net_id
     port_dict["status"] = "ACTIVE"  # TODO do we support inactive port?
     port_dict["tenant_id"] = "cf1a5775e766426cb1968766d0191908"  # TODO find real tenant_id
     return port_dict
 
 
-def calculate_start_and_end_dict(cidr):
-    address, suffix = cidr.rsplit('/', 1)
-    int_suffix = int(suffix)
-    int_address = ip_2_int(address)
-    address_space = 2**32 - 1
-
-    for x in range(0, 31-int_suffix):
-        address_space = ~(~address_space | (1 << x))
-
-    start = int_address & address_space
-    end = start + (2**(32-int_suffix) - 1)
-
-    return {'start': int_2_ip(start), 'end': int_2_ip(end)}
-
-
-def ip_2_int(ip):
-    o = map(int, ip.split('.'))
-    res = (16777216 * o[0]) + (65536 * o[1]) + (256 * o[2]) + o[3]
-    return res
-
-
-def int_2_ip(int_ip):
-    o1 = int(int_ip / 16777216) % 256
-    o2 = int(int_ip / 65536) % 256
-    o3 = int(int_ip / 256) % 256
-    o4 = int(int_ip) % 256
-    return '%(o1)s.%(o2)s.%(o3)s.%(o4)s' % locals()
-
-
 def create_link(net_id):
     for stack in compute.stacks.values():
-        for net in stack.nets.values():
-            if net.id == net_id:
-                tmp_server = None
-                for server in stack.servers.values():
-                    for port in server.ports:  # TODO new ports are currently not added to any server.ports dict
-                        if port.net.id == net_id:
-                            tmp_server = server
-
-                if tmp_server is not None:
+        for server in stack.servers.values():
+            for port_name in server.ports:  # TODO new ports are currently not added to any server.ports dict
+                port = stack.ports[port_name]
+                if port.net_id == net_id:
                     compute.dc.net.addLink(
-                        compute.dc.containers[tmp_server.name],
+                        compute.dc.containers[server.name],
                         compute.dc.switch,
-                        params1={"ip": str(net.cidr)},
+                        params1={"ip": str(port.ip_address)},
                         cls=Link,
-                        intfName1=net.id)
-                else:
-                    print('AAAAAAAAAAAHHHHHHHHHHHHHHHHHH server-class not found!!')
+                        intfName1=port.net_id)

--- a/src/emuvim/api/heat/resources/net.py
+++ b/src/emuvim/api/heat/resources/net.py
@@ -1,3 +1,5 @@
+import re
+
 class Net:
     def __init__(self, name, id=None, subnet_name=None, subnet_id=None, segmentation_id=None, cidr=None):
         self.name = name
@@ -6,13 +8,86 @@ class Net:
         self.subnet_id = subnet_id
         self.gateway_ip = None
         self.segmentation_id = segmentation_id  # not set
-        self.cidr = cidr
+        self._cidr = cidr
+        self.start_end_dict = None
+        self._issued_ip_addresses = dict()
+
+    def get_new_ip_address(self, port_name):
+        if self.start_end_dict is None:
+            return None
+
+        int_start_ip = self.ip_2_int(self.start_end_dict['start'])
+        int_end_ip = self.ip_2_int(self.start_end_dict['end'])
+        while int_start_ip in self._issued_ip_addresses and int_start_ip <= int_end_ip:
+            int_start_ip+=1
+
+        if int_start_ip > int_end_ip:
+            return None
+
+        self._issued_ip_addresses[int_start_ip] = port_name
+        return self.int_2_ip(int_start_ip) + '/' + self._cidr.rsplit('/', 1)[1]
+
+    def withdraw_ip_address(self, ip_address):
+        address, suffix = ip_address.rsplit('/', 1)
+        int_ip_address = self.ip_2_int(address)
+        del self._issued_ip_addresses[int_ip_address]
+
+    def reset_issued_ip_addresses(self):
+        self._issued_ip_addresses = dict()
+
+    def update_port_name_for_ip_address(self, ip_address, port_name):
+        address, suffix = ip_address.rsplit('/', 1)
+        int_ip_address = self.ip_2_int(address)
+        self._issued_ip_addresses[int_ip_address] = port_name
+
+    def set_cidr(self, cidr):
+        if cidr is None:
+            self._cidr = None
+            return True
+        if not self.check_cidr_format(cidr):
+            return False
+        self.start_end_dict = self.calculate_start_and_end_dict(cidr)
+        self._cidr = cidr
+        return True
+
+    def calculate_start_and_end_dict(self, cidr):
+        address, suffix = cidr.rsplit('/', 1)
+        int_suffix = int(suffix)
+        int_address = self.ip_2_int(address)
+        address_space = 2 ** 32 - 1
+
+        for x in range(0, 31 - int_suffix):
+            address_space = ~(~address_space | (1 << x))
+
+        start = int_address & address_space
+        end = start + (2 ** (32 - int_suffix) - 1)
+
+        return {'start': self.int_2_ip(start), 'end': self.int_2_ip(end)}
+
+    def ip_2_int(self, ip):
+        o = map(int, ip.split('.'))
+        res = (16777216 * o[0]) + (65536 * o[1]) + (256 * o[2]) + o[3]
+        return res
+
+    def int_2_ip(self, int_ip):
+        o1 = int(int_ip / 16777216) % 256
+        o2 = int(int_ip / 65536) % 256
+        o3 = int(int_ip / 256) % 256
+        o4 = int(int_ip) % 256
+        return '%(o1)s.%(o2)s.%(o3)s.%(o4)s' % locals()
+
+    def check_cidr_format(self, cidr):
+        r = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{2}')
+        if r.match(cidr):
+            return True
+        return False
 
     def __eq__(self, other):
         if self.name == other.name and self.subnet_name == other.subnet_name and \
                                        self.gateway_ip == other.gateway_ip and \
                                        self.segmentation_id == other.segmentation_id and \
-                                       self.cidr == other.cidr:
+                                       self._cidr == other._cidr and \
+                                       self.start_end_dict == other.start_end_dict:
             return True
         return False
 
@@ -21,4 +96,5 @@ class Net:
                      self.subnet_name,
                      self.gateway_ip,
                      self.segmentation_id,
-                     self.cidr))
+                     self._cidr,
+                     self.start_end_dict))

--- a/src/emuvim/api/heat/resources/port.py
+++ b/src/emuvim/api/heat/resources/port.py
@@ -6,13 +6,13 @@ class Port:
         self.ip_address = ip_address    # not set
         self.mac_address = mac_address  # not set
         self.floating_ip = floating_ip
-        self.net = None
+        self.net_id = None
 
     def __eq__(self, other):
         if self.name == other.name and self.ip_address == other.ip_address and \
                                        self.mac_address == other.mac_address and \
                                        self.floating_ip == other.floating_ip and \
-                                       self.net == other.net:
+                                       self.net_id == other.net:
             return True
         return False
 
@@ -20,4 +20,5 @@ class Port:
         return hash((self.name,
                      self.ip_address,
                      self.mac_address,
-                     self.floating_ip))
+                     self.floating_ip,
+                     self.net_id))


### PR DESCRIPTION
Some small style and error fixes.
All ports, nets and subnets will now get UUIDs which are currently only 15 characters long because longer ids will lead to errors (mininet wont create network connections with long namens).
All objects are now referred to via name or id if they are needed in other classes (e.g. ports need the net class and now they only have the net_id). This avoids inconsistency because the object is onld stored in the stack->dict (I could not figure out any good solution with pointers in Python).
A neutron call to create a network will now return an error message if no stack is found.
The net class now contains the allocation pool - thus it does not need to be computed each time.