### PR TITLE
remove the floating switch from topo call

### DIFF
--- a/src/emuvim/api/heat/chain_api.py
+++ b/src/emuvim/api/heat/chain_api.py
@@ -594,10 +594,13 @@ class QueryTopology(Resource):
             graph = self.api.manage.net.DCNetwork_graph
             topology = dict()
             for n in graph:
-                if n != "root":
+                # remove root node as well as the floating switch fs1
+                if n != "root" and n != "fs1":
                     topology[n] = copy.copy(graph[n])
                     if "root" in topology[n]:
                         del topology[n]["root"]
+                    if "fs1" in topology[n]:
+                        del topology[n]["fs1"]
 
             return Response(json.dumps(topology),
                             status=200, mimetype="application/json")

--- a/src/emuvim/dcemulator/net.py
+++ b/src/emuvim/dcemulator/net.py
@@ -183,7 +183,7 @@ class DCNetwork(Containernet):
         edge_attributes = [p for p in params if p in weight_metrics]
         for attr in edge_attributes:
             # if delay: strip ms (need number as weight in graph)
-            match = re.search('([0-9]*\.?[0-9]+)', params[attr])
+            match = re.search('([0-9]*\.?[0-9]+)', str(params[attr]))
             if match:
                 attr_number = match.group(1)
             else:


### PR DESCRIPTION
also already fix the bug that link attributes that are not of type string do not work.